### PR TITLE
login/signup page dom attribute for email input field chrome console warning fixed

### DIFF
--- a/views/login.handlebars
+++ b/views/login.handlebars
@@ -19,7 +19,7 @@
                                         <div class="form-outline flex-fill mb-0"></div> {{!-- mb-0 eliminates the margin
                                         bottom --}}
                                         {{!-- email autocomplete DOM best practice: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete --}}
-                                        <input type="email" autocomplete="email" id="typeEmailX"
+                                        <input type="email" autocomplete="username email" id="typeEmailX, email"
                                             placeholder="Email e.g. feedsterfan2021@gmail.com"
                                             class="form-control form-control-lg" required/> {{!-- marked the field
                                         required and added a pattern pattern="^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$" --}}

--- a/views/signup.handlebars
+++ b/views/signup.handlebars
@@ -31,7 +31,8 @@
                     {{! added a font icon }}
                     <div class="form-outline flex-fill mb-0"></div>
                     {{! mb-0 eliminates the margin bottom }}
-                    <input type="email" id="typeEmailX" placeholder="Email e.g. feedsterfan2021@gmail.com"
+                   {{!-- fixed the dom warning in chrome browsers as defined here: https://stackoverflow.com/questions/48525114/chrome-warning-dom-password-forms-should-have-optionally-hidden-username-fi --}}
+                    <input type="email" id="typeEmailX, email" autocomplete="username email" placeholder="Email e.g. feedsterfan2021@gmail.com"
                       class="form-control form-control-lg" required />
                     {{! marked the field required and added, a pattern . referenced :
                     https://docs.netapp.com/oci-73/index.jsp?topic=%2Fcom.netapp.doc.oci-acg%2FGUID-452051E1-0F8B-415E-87FE-D8AD97881072.html


### PR DESCRIPTION
Fixed the "DOM Attribute for email input field" chrome console warning for the login/signup pages by adding an autocomplete section for password managers to parse the input properly.. 